### PR TITLE
Added missing HttpKernel\Util\Filesystem class

### DIFF
--- a/compile
+++ b/compile
@@ -125,6 +125,7 @@ $classes = array(
     'Symfony\Component\HttpFoundation\Response',
     'Symfony\Component\HttpFoundation\ResponseHeaderBag',
     'Symfony\Component\HttpKernel\Event\FilterResponseEvent',
+    'Symfony\Component\HttpKernel\Util\Filesystem',
 );
 
 @unlink(__DIR__.'/build/sismo.php');


### PR DESCRIPTION
The downloaded `sismo.php` was giving me this error, when trying to build:

`PHP Fatal error:  Class 'Symfony\Component\HttpKernel\Util\Filesystem' not found in /var/www/sismo.php on line 38`

git clone --recursive, added the class, and compiled from source, and it started working.
