### PR TITLE
Footer rendering as inline

### DIFF
--- a/web/css/sismo.css
+++ b/web/css/sismo.css
@@ -163,6 +163,7 @@ footer {
     font-size: 12px;
     font-family: Arial;
     background: #274751 url(../images/hr.png) no-repeat;
+    display: block;
 }
 
 footer span {


### PR DESCRIPTION
The &lt;footer&gt; tag renders as an inline by default on certain browsers with limited HTML5 support. This will fix the issue on most browsers (except IE8 and below) by adding display: block; to the footer CSS.
