### PR TITLE
Issue #13: Build time has wrong time. i is the correct format code 

### DIFF
--- a/src/templates/project.twig
+++ b/src/templates/project.twig
@@ -43,7 +43,7 @@
         <span class="permalink"><a href="{{ path('commit', { 'slug': commit.project.slug, 'sha': commit.sha }) }}">¶</a></span>
     </h2>
     <div class="meta">
-        by <em>{{ commit.author }}</em> on <em>{{ commit.date|date('j M Y H:m') }}</em>
+        by <em>{{ commit.author }}</em> on <em>{{ commit.date|date('j M Y H:i') }}</em>
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
As choffmeister mentioned in Issue #13 the build time always has the same minutes. The reason was that the date format H:m display the month instead of minutes. Use H:i instead.
