### PR TITLE
show popup on current logged user display (linux)

### DIFF
--- a/src/Sismo/DBusNotifier.php
+++ b/src/Sismo/DBusNotifier.php
@@ -21,15 +21,16 @@ use Symfony\Component\Process\Process;
  */
 class DBusNotifier extends Notifier
 {
-    public function __construct($format = "[%STATUS%]\n%message%\n%author%", $port = 9887)
+    public function __construct($display = "", $format = "[%STATUS%]\n%message%\n%author%")
     {
-        $this->format = $format;
+        $this->display = $display;
+        $this->format  = $format;
     }
 
     public function notify(Commit $commit)
     {
         // first, try with the notify-send program
-        $process = new Process(sprintf('notify-send "%s" "%s"', $commit->getProject()->getName(), $this->format($this->format, $commit)));
+        $process = new Process(sprintf('%s notify-send "%s" "%s"', $this->display, $commit->getProject()->getName(), $this->format($this->format, $commit)));
         $process->setTimeout(2);
         $process->run();
         if ($process->getExitCode() <= 0) {


### PR DESCRIPTION
This is useful, because when the process runs as a post-commit hook or
on a cron job, the user that runs the command might be not the same as
the current user logged in.
This allows to set the display as: DISPLAY=:0.0 (or any other display
you want), so that the notify-send pop-up shows on the currently
logged in user display.

the user can now define their notifier in their config as:
// create a DBus notifier (for Linux)
$notifier = new Sismo\DBusNotifier('DISPLAY=:0.0');
## previous comment for reference only:

the notify-send command did not display the notification for me, when ran by the apache user, since it wasn't being ran by the current user logged in.

Looked online and found this issue also comes up when running it as a cron job, and it's just a matter of appending DISPLAY=:0 before running the command.

DISPLAY=:0 just tells the script to launch the popup on the main screen of the current logged in user
Here are a couple of solutions pointing to this, that I found, just for reference:
http://ubuntuforums.org/showpost.php?p=9604447&postcount=3
http://ubuntuforums.org/showpost.php?p=9608842&postcount=4
