### PR TITLE
Avoid  routing conflicts between assets & dynamic routes

### DIFF
--- a/compile
+++ b/compile
@@ -191,8 +191,8 @@ $classes
 $bootstrap
 $templates
 $cli
-$app
 $assets
+$app
 
 namespace {
     if ('cli' === php_sapi_name()) {


### PR DESCRIPTION
/{var1}/{var2} vs /css/sismo.css

Thanks, for merging this contrib. Without this patch, the images & css are not loaded in compiled version of Sismo. Please also update sismo.php from sismo-project.com.  
