### PR TITLE
quote path names within git clone command

### DIFF
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -33,7 +33,7 @@ class Builder
         $this->baseBuildDir = $buildDir;
         $this->gitPath = $gitPath;
         $this->gitCmds = array_replace(array(
-            'clone'    => 'clone --progress --recursive "%repo%" "%dir%"',
+            'clone'    => 'clone --progress --recursive %repo% %dir%',
             'fetch'    => 'fetch origin',
             'prepare'  => 'submodule update --init --recursive',
             'checkout' => 'checkout origin/%branch%',
@@ -67,7 +67,7 @@ class Builder
         }
 
         if (!file_exists($this->buildDir.'/.git')) {
-            $this->execute(strtr($this->gitPath.' '.$this->gitCmds['clone'], array('%repo%' => $this->project->getRepository(), '%dir%' => $this->buildDir)), sprintf('Unable to clone repository for project "%s".', $this->project));
+            $this->execute(strtr($this->gitPath.' '.$this->gitCmds['clone'], array('%repo%' => escapeshellarg($this->project->getRepository()), '%dir%' => escapeshellarg($this->buildDir))), sprintf('Unable to clone repository for project "%s".', $this->project));
         }
 
         if ($sync) {


### PR DESCRIPTION
The quotes are required to be able
to configure paths with spaces in themselves.

Log:

<pre>
~/Web Development/Sismo (master u=) $ php sismo build cronparser-local -v
Building Project "CronParser (Local)" (into "0536c7")

OUT| Running "git clone --progress --recursive /Users/havvg/Web Development/CronParser/ /Users/havvg/.sismo/data/build/0536c7"
OUT| 
ERR| Too many arguments.
ERR| 
ERR| usage: git clone [options] [--] <repo> [<dir>]
ERR| 
ERR|     -v, --verbose         be more verbose
ERR|     -q, --quiet           be more quiet
ERR|     --progress            force progress reporting
ERR|     -n, --no-checkout     don't create a checkout
ERR|     --bare                create a bare repository
ERR|     --mirror              create a mirror repository (implies bare)
ERR|     -l, --local           to clone from a local repository
ERR|     --no-hardlinks        don't use local hardlinks, always copy
ERR|     -s, --shared          setup as shared repository
ERR|     --recursive           initialize submodules in the clone
ERR|     --recurse-submodules  initialize submodules in the clone
ERR|     --template <template-directory>
ERR|                           directory from which templates will be used
ERR|     --reference <repo>    reference repository
ERR|     -o, --origin <branch>
ERR|                           use <branch> instead of 'origin' to track upstream
ERR|     -b, --branch <branch>
ERR|                           checkout <branch> instead of the remote's HEAD
ERR|     -u, --upload-pack <path>
ERR|                           path to git-upload-pack on the remote
ERR|     --depth <depth>       create a shallow clone of that depth
ERR| 
ERR| 
Unable to clone repository for project "CronParser (Local)".
~/Web Development/Sismo (master u=) $ git stash pop
# On branch master
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#   modified:   src/Sismo/Builder.php
#
no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (718054c773033064f1f45e51900b93e6f0c9f0da)
~/Web Development/Sismo (master u=) $ git di -w
diff --git a/src/Sismo/Builder.php b/src/Sismo/Builder.php
index 946e894..2140098 100644
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -33,7 +33,7 @@ class Builder
         $this->baseBuildDir = $buildDir;
         $this->gitPath = $gitPath;
         $this->gitCmds = array_replace(array(
-            'clone'    => 'clone --progress --recursive %repo% %dir%',
+            'clone'    => 'clone --progress --recursive "%repo%" "%dir%"',
             'fetch'    => 'fetch origin',
             'prepare'  => 'submodule update --init --recursive',
             'checkout' => 'checkout origin/%branch%',
~/Web Development/Sismo (master u=) $ php sismo build cronparser-local -v
Building Project "CronParser (Local)" (into "0536c7")

OUT| Running "git clone --progress --recursive "/Users/havvg/Web Development/CronParser/" "/Users/havvg/.sismo/data/build/0536c7""
OUT| Cloning into /Users/havvg/.sismo/data/build/0536c7...
OUT| done.
OUT| Running "git fetch origin"
OUT| Running "git submodule update --init --recursive"
OUT| Running "git checkout origin/master"
OUT| 
ERR| HEAD is now at 7584242... added test cases for n-th of month
ERR| 
OUT| Running "git reset --hard 7584242a4ec909c187a324d2ac39c68c474717ee"
OUT| HEAD is now at 7584242 added test cases for n-th of month
OUT| Running "git show -s --pretty=format:"%H%n%an%n%ci%n%s%n" 7584242a4ec909c187a324d2ac39c68c474717ee"
OUT| 7584242a4ec909c187a324d2ac39c68c474717ee
OUT| Toni Uebernickel
OUT| 2011-04-12 15:19:38 +0200
OUT| added test cases for n-th of month
OUT| 
</pre>
