### PR TITLE
fixed SismoTest expectations on Process

### DIFF
--- a/tests/Sismo/Tests/SismoTest.php
+++ b/tests/Sismo/Tests/SismoTest.php
@@ -172,7 +172,7 @@ class SismoTest extends \PHPUnit_Framework_TestCase
     {
         // build is a success
         $process = $this->getProcess();
-        $process->expects($this->once())->method('getExitCode')->will($this->returnValue(0));
+        $process->expects($this->once())->method('isSuccessful')->will($this->returnValue(true));
         $process->expects($this->once())->method('getOutput')->will($this->returnValue('foo'));
 
         // build is triggered as commit does not exist
@@ -198,7 +198,7 @@ class SismoTest extends \PHPUnit_Framework_TestCase
     {
         // build is a fail
         $process = $this->getProcess();
-        $process->expects($this->once())->method('getExitCode')->will($this->returnValue(1));
+        $process->expects($this->once())->method('isSuccessful')->will($this->returnValue(false));
         $process->expects($this->once())->method('getOutput')->will($this->returnValue('foo'));
         $process->expects($this->once())->method('getErrorOutput')->will($this->returnValue('bar'));
 


### PR DESCRIPTION
Sismo::build() does not check for an exit code of the Process directly to decide whether the build failed or not, but it checks for Process::isSuccessful() to be true.

Log:

<pre>
~/Web Development/Sismo (master u=) $ phpunit
PHPUnit 3.5.14 by Sebastian Bergmann.

.....................................................FF....

Time: 0 seconds, Memory: 23.75Mb

There were 2 failures:

1) Sismo\Tests\SismoTest::testCommitResultForSuccessBuild
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-success
+failed

/Users/havvg/Web Development/Sismo/src/Sismo/Sismo.php:60
/Users/havvg/Web Development/Sismo/tests/Sismo/Tests/SismoTest.php:194

2) Sismo\Tests\SismoTest::testCommitResultForSuccessFail
Expectation failed for method name is equal to <string:getExitCode> when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.


FAILURES!
Tests: 59, Assertions: 199, Failures: 2.
~/Web Development/Sismo (master u=) $ git co fix-sismo-test 
Switched to branch 'fix-sismo-test'
~/Web Development/Sismo (fix-sismo-test u=) $ phpunit
PHPUnit 3.5.14 by Sebastian Bergmann.

...........................................................

Time: 0 seconds, Memory: 23.25Mb

OK (59 tests, 208 assertions)
</pre>
