### PR TITLE
fixed git show format being escaped twice

### DIFF
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -38,7 +38,7 @@ class Builder
             'prepare'  => 'submodule update --init --recursive',
             'checkout' => 'checkout origin/%branch%',
             'reset'    => 'reset --hard %revision%',
-            'show'     => 'show -s --pretty=format:"%format%" %revision%',
+            'show'     => 'show -s --pretty=format:%format% %revision%',
         ), $gitCmds);
     }
 


### PR DESCRIPTION
Introduced by 00a3beb762274b9fa377b5b00302c4e9d3f26113 the format option of
`git show` shows up a single quote within itself e.g.

`git show -s --pretty=format:"'%H%n%an%n%ci%n%s%n'" 'ef499980ac8b7b07636bd58029f2c137037fd19c'`

This breaks the hashes and messages of commits with a leading and trailing quote, respectively.
