### PR TITLE
add static default command to Sismo\Project

### DIFF
--- a/src/Sismo/Project.php
+++ b/src/Sismo/Project.php
@@ -20,11 +20,13 @@ use Sismo\Notifier\Notifier;
  */
 class Project
 {
+    protected static $defaultCommand = 'phpunit';
+
     protected $name;
     protected $slug;
     protected $repository;
     protected $branch = 'master';
-    protected $command = 'phpunit';
+    protected $command;
     protected $urlPattern;
     protected $commits = array();
     protected $building = false;
@@ -42,6 +44,7 @@ class Project
     {
         $this->name = $name;
         $this->slug = $slug ?: $this->slugify($name);
+        $this->command = static::$defaultCommand;
 
         if (null !== $repository) {
             $this->setRepository($repository);
@@ -313,6 +316,11 @@ class Project
     public function setCommand($command)
     {
         $this->command = $command;
+    }
+
+    public static function setDefaultCommand($command)
+    {
+        self::$defaultCommand = $command;
     }
 
     /**

--- a/tests/Sismo/Tests/ProjectTest.php
+++ b/tests/Sismo/Tests/ProjectTest.php
@@ -195,6 +195,20 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/path/to/phpunit', $project->getCommand());
     }
 
+    public function testDefaultCommand()
+    {
+        $project = new Project('Twig Local');
+        $this->assertEquals('phpunit', $project->getCommand());
+
+        Project::setDefaultCommand('phpunit --colors --strict');
+        $project2 = new Project('Twig Local');
+        $this->assertEquals('phpunit', $project->getCommand());
+        $this->assertEquals('phpunit --colors --strict', $project2->getCommand());
+
+        $project2->setCommand('phpunit');
+        $this->assertEquals('phpunit', $project2->getCommand());
+    }
+
     public function testUrlPattern()
     {
         $project = new Project('Twig Local');


### PR DESCRIPTION
This allows to alter the default command for all newly created projects with just one line.

It's meant to be used in the config.file of Sismo to (for example) change the default options of the phpunit command to run or even change the test suite to run at all.

Example:

``` php
<?php

$projects = array();
$notifier = new Sismo\GrowlNotifier('pa$$word');

\Sismo\Project::setDefaultCommand('phpunit --colors --strict');

$projects[] = new Sismo\GithubProject('Twig (Local)', '/Users/fabien/Twig', $notifier);
$projects[] = new Sismo\GithubProject('Twig', 'fabpot/Twig', $notifier);

return $projects;
```
