### PR TITLE
add MailNotifier

### DIFF
--- a/src/Sismo/Contrib/MailNotifier.php
+++ b/src/Sismo/Contrib/MailNotifier.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sismo utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sismo\Contrib;
+
+use Sismo\Notifier;
+use Sismo\Commit;
+
+// @codeCoverageIgnoreStart
+/**
+ * A base email notifier using the native mail() function.
+ *
+ * @author Toni Uebernickel <tuebernickel@gmail.com>
+ */
+class MailNotifier extends Notifier
+{
+    protected $recipients;
+    protected $subjectFormat;
+    protected $messageFormat;
+    protected $headers;
+    protected $params;
+
+    /**
+     * Constructor.
+     *
+     * @param array|string $recipients
+     * @param string $subjectFormat
+     * @param string $messageFormat
+     * @param string $headers Additional headers applied to the email.
+     * @param string $params Additional params to be used on mail()
+     */
+    public function __construct($recipients, $subjectFormat = '', $messageFormat = '', $headers = '', $params = '')
+    {
+        $this->recipients = $recipients;
+        $this->subjectFormat = $subjectFormat;
+        $this->messageFormat = $messageFormat;
+        $this->headers = $headers;
+        $this->params = $params;
+    }
+
+    public function notify(Commit $commit)
+    {
+        $subject = $this->format($this->subjectFormat, $commit);
+        $message = $this->format($this->messageFormat, $commit);
+
+        return $this->sendEmail($this->recipients, $subject, $message, $this->headers, $this->params);
+    }
+
+    /**
+     * Send the email.
+     *
+     * @param array|string $to
+     * @param string $subject
+     * @param string $message
+     * @param string $headers Additional headers to send.
+     * @param string $params Additional params for the mailer in use.
+     *
+     * @return bool Whether the mail has been sent.
+     */
+    protected function sendEmail($to, $subject, $message, $headers = '', $params = '')
+    {
+        if (is_array($to)) {
+            $to = implode(',', $to);
+        }
+
+        return mail($to, $subject, $message, $headers, $params);
+    }
+}
+// @codeCoverageIgnoreEnd

--- a/src/Sismo/Notifier.php
+++ b/src/Sismo/Notifier.php
@@ -39,6 +39,7 @@ abstract class Notifier
             '%short_sha%'   => $commit->getShortSha(),
             '%author%'      => $commit->getAuthor(),
             '%message%'     => $commit->getMessage(),
+            '%output%'      => $commit->getOutput(),
         );
     }
 }


### PR DESCRIPTION
A basic notifier sending emails using native `mail` function.

It supports subject and message formatting.

Example Configuration:

``` php
<?php

$project = new Sismo\Project('Ormigo.com@develop', __DIR__);
$project->setBranch('develop');
$project->setCommand('phpunit --coverage-text && php app/console behat -e=test --no-ansi');

$subject = '[%status_code%] %name% (%short_sha%)';
$message = <<<MESSAGE
  Build status changed to %STATUS%.

    commit: %sha%
    Author: %author%

    %message%

    Sismo reports:

    %output%
MESSAGE;

$emailNotifier = new Sismo\Contrib\MailNotifier('dev@ormigo.com', $subject, $message);
$project->addNotifier($emailNotifier);

return $project;
```
