### PR TITLE
escape repository on command line

### DIFF
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -110,7 +110,7 @@ class Builder
     protected function getGitCommand($command, array $replace = array())
     {
         $replace = array_merge(array(
-            '%repo%'        => $this->project->getRepository(),
+            '%repo%'        => escapeshellarg($this->project->getRepository()),
             '%dir%'         => escapeshellarg($this->buildDir),
             '%branch%'      => escapeshellarg('origin/'.$this->project->getBranch()),
             '%localbranch%' => escapeshellarg($this->project->getBranch()),


### PR DESCRIPTION
This is required to have e.g. local repositories with spaces in their directory path working.
