### PR TITLE
Fix composer.json validation error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "sismo/sismo",
-    "type": "silex application",
+    "type": "silex-application",
     "description": "Sismo is a personal continuous integration server.",
-    "keywords": ["sismo, continuous integration"],
+    "keywords": ["sismo", "continuous integration"],
     "homepage": "http://sismo.sensiolabs.org",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
When running composer the composer.json had validation issues

``` cli
$ composer.phar validate
    ./composer.json is invalid, the following errors/warnings were found:
    type : invalid value, must match [a-z0-9-]+
    keywords.0 : invalid value, must match [A-Za-z0-9 -]+
```
