### PR TITLE
Fix git checkout bug :: git checkout returns STDERR instead of STDOUT

### DIFF
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -36,7 +36,7 @@ class Builder
             'clone'    => 'clone --progress --recursive %repo% %dir% --branch %localbranch%',
             'fetch'    => 'fetch origin',
             'prepare'  => 'submodule update --init --recursive',
-            'checkout' => 'checkout %branch%',
+            'checkout' => 'checkout -q %branch%',
             'reset'    => 'reset --hard %revision%',
             'show'     => 'show -s --pretty=format:%format% %revision%',
         ), $gitCmds);


### PR DESCRIPTION
When building a project stderr is returned by git when it intends stdout. Following command prints to stderr and causes error

```
$ git checkout 'origin/master'
    HEAD is now at 43329a9... update MongoRecord
```

Dumping $process

``` php
// Builder.php::execute() | var_dump($process);
object(Symfony\Component\Process\Process)#159 (16) {
  ["commandline":"Symfony\Component\Process\Process":private]=>
  string(28) "git checkout 'origin/master'"
  ["cwd":"Symfony\Component\Process\Process":private]=>
  string(36) "/Users/Ryan/.sismo/data/build/ac1276"
  ["env":"Symfony\Component\Process\Process":private]=>
  NULL
  ["stdin":"Symfony\Component\Process\Process":private]=>
  NULL
  ["timeout":"Symfony\Component\Process\Process":private]=>
  int(3600)
  ["options":"Symfony\Component\Process\Process":private]=>
  array(2) {
    ["suppress_errors"]=>
    bool(true)
    ["binary_pipes"]=>
    bool(true)
  }
  ["exitcode":"Symfony\Component\Process\Process":private]=>
  int(0)
  ["processInformation":"Symfony\Component\Process\Process":private]=>
  array(8) {
    ["command"]=>
    string(28) "git checkout 'origin/master'"
    ["pid"]=>
    int(61774)
    ["running"]=>
    bool(false)
    ["signaled"]=>
    bool(false)
    ["stopped"]=>
    bool(false)
    ["exitcode"]=>
    int(0)
    ["termsig"]=>
    int(0)
    ["stopsig"]=>
    int(0)
  }
  ["stdout":"Symfony\Component\Process\Process":private]=>
  string(0) ""
  ["stderr":"Symfony\Component\Process\Process":private]=>
  string(45) "HEAD is now at 43329a9... update MongoRecord
"
  ["enhanceWindowsCompatibility":"Symfony\Component\Process\Process":private]=>
  bool(true)
  ["pipes":"Symfony\Component\Process\Process":private]=>
  array(0) {
  }
  ["process":"Symfony\Component\Process\Process":private]=>
  resource(23) of type (Unknown)
  ["status":"Symfony\Component\Process\Process":private]=>
  string(10) "terminated"
  ["fileHandles":"Symfony\Component\Process\Process":private]=>
  NULL
  ["readBytes":"Symfony\Component\Process\Process":private]=>
  NULL
}
```

Surprisingly adding `git checkout -q 'origin/master'` will suppress that error yet still return stderr. After browsing the net there are a number of issues where git uses stderr instead of stdout.
