### PR TITLE
Added MailNotifier in compile script.

### DIFF
--- a/compile
+++ b/compile
@@ -119,6 +119,7 @@ $classes = array (
     'Sismo\Contrib\GoogleTalkNotifier',
     'Sismo\Notifier\DBusNotifier',
     'Sismo\Notifier\GrowlNotifier',
+    'Sismo\Notifier\MailNotifier',
     'Sismo\Notifier\Notifier',
     'Sismo\Project',
     'Sismo\GithubProject',


### PR DESCRIPTION
It seems the MailNotifier class is missing in the compile script.
