### PR TITLE
Added Twig_Extension_Debug in compiled files

### DIFF
--- a/compile
+++ b/compile
@@ -19,6 +19,7 @@ $classes = array (
     'Twig_Error_Syntax',
     'Twig_Extension',
     'Twig_Extension_Core',
+    'Twig_Extension_Debug',
     'Twig_Extension_Escaper',
     'Twig_Extension_Optimizer',
     'Twig_Filter',


### PR DESCRIPTION
If I add `$app['debug'] = true` in config.php I have this error :

```
2013/01/14 12:07:30 [error] 7301#0: *215 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Class 'Twig_Extension_Debug' not found in /xxxxxxx/web/sismo.php on line 78" while reading response header from upstream, client: xxxxx, server: xxxxx, request: "GET /xxxxxx HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "xxxxxx", referrer: "xxxxxx"
```

This PR fix the problem.
