### PR TITLE
Fix bitbucket project setRepository method

### DIFF
--- a/src/Sismo/BitbucketProject.php
+++ b/src/Sismo/BitbucketProject.php
@@ -35,7 +35,7 @@ class BitbucketProject extends Project
                     break;
                 }
             }
-        } elseif (preg_match('#^[a-z0-9_-]+/[a-z0-9_-]+$#i', $this->getRepository())) {
+        } elseif (preg_match('#^[a-z0-9_.-]+/[a-z0-9_.-]+$#i', $this->getRepository())) {
             $repo = preg_split('/\//', $this->getRepository());
 
             $this->setUrlPattern(sprintf('https://bitbucket.org/%s/changeset/%%commit%%', $this->getRepository()));

--- a/tests/Sismo/Tests/BitbucketProjectTest.php
+++ b/tests/Sismo/Tests/BitbucketProjectTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sismo utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sismo\Tests;
+
+use Sismo\BitbucketProject;
+
+class BitbucketProjectTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getRepositoryProvider
+     */
+    public function testThatItSetRepository($repositoryPath, $branch, $repository, $urlPattern)
+    {
+        $project = new BitbucketProject('Twig', $repositoryPath);
+        $this->assertEquals($branch, $project->getBranch());
+        $this->assertEquals($repository, $project->getRepository());
+        $this->assertEquals($urlPattern, $project->getUrlPattern());
+    }
+
+    public function getRepositoryProvider()
+    {
+        return array(
+            array('acme/Demo', 'master', 'git@bitbucket.org:/acme/Demo.git', 'https://bitbucket.org/acme/Demo/changeset/%commit%'),
+            array('acme/Demo@develop', 'develop', 'git@bitbucket.org:/acme/Demo.git', 'https://bitbucket.org/acme/Demo/changeset/%commit%'),
+            array('acme/no.no1', 'master', 'git@bitbucket.org:/acme/no.no1.git', 'https://bitbucket.org/acme/no.no1/changeset/%commit%'),
+            array('no.no/acme', 'master', 'git@bitbucket.org:/no.no/acme.git', 'https://bitbucket.org/no.no/acme/changeset/%commit%'),
+            array('acme/no_no1', 'master', 'git@bitbucket.org:/acme/no_no1.git', 'https://bitbucket.org/acme/no_no1/changeset/%commit%'),
+            array('acme/no-no1', 'master', 'git@bitbucket.org:/acme/no-no1.git', 'https://bitbucket.org/acme/no-no1/changeset/%commit%'),
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetRepositoryThrowsAnExceptionIfRepositoryIsNotAGithubOne()
+    {
+        $project = new BitbucketProject('Twig', 'fabpot/Twig/foobar');
+    }
+}


### PR DESCRIPTION
Fix bitbucket project which throwed exception when repo looks like 'some/repo.1' which is actually totaly valid one.
