### PR TITLE
Better Git post-commit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,8 @@ appending ``--help``:
 
     $ php sismo.php build --help
 
-To make Sismo run whenever you commit some changes, save this script in your project as ``.git/hooks/post-commit`` and make sure it's executable:
+To make Sismo run whenever you commit some changes, save this script in your
+project as ``.git/hooks/post-commit`` and make sure it's executable:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The current Git post-commit script on http://sismo.sensiolabs.org seems to have unnecessary backslashes. In addition the build command doesn't terminate the commit hook immediately and thus hangs the Git commit command. Using --force makes sure the tests are run even when git commit --amend has been used.
