### PR TITLE
escaped manually the shell arg (fixes #93)

### DIFF
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -117,7 +117,7 @@ class Builder
             '%dir%'         => escapeshellarg($this->buildDir),
             '%branch%'      => escapeshellarg('origin/'.$this->project->getBranch()),
             '%localbranch%' => escapeshellarg($this->project->getBranch()),
-            '%format%'      => escapeshellarg('%H%n%an%n%ci%n%s%n'),
+            '%format%'      => '"%H%n%an%n%ci%n%s%n"',
         ), $replace);
 
         return strtr($this->gitPath.' '.$this->gitCmds[$command], $replace);


### PR DESCRIPTION
I've been able to dig into my issue (#93), the stack trace is pretty explicit, at some point it tries to execute `git show -s --pretty=format:" H n an n ci n s n" "ac86c6368c8b1ed
27adb436af54d0398b64cab1f"`, the format is wrong, percents (%) are missing, it's because I'm on windows, and `escapeshellargs()` is replacing percents by spaces (https://github.com/fabpot/Sismo/blob/master/src/Sismo/Builder.php#L120).

I'm suggesting to remove the call to this function, this parameter is hardcoded (plain string) so can't it be trusted? What do you think?

BTW: thx for this great tool!
