### PR TITLE
Do not stop building all projects if a single project throws a build exc...

### DIFF
--- a/src/console.php
+++ b/src/console.php
@@ -213,6 +213,7 @@ EOF
             $flags = $flags | Sismo::SILENT_BUILD;
         }
 
+        $returnValue = 0;
         foreach ($projects as $project) {
             // out of time?
             if ($input->getOption('timeout') && time() - $start > $input->getOption('timeout')) {
@@ -227,9 +228,10 @@ EOF
             } catch (BuildException $e) {
                 $output->writeln("\n".sprintf('<error>%s</error>', $e->getMessage()));
 
-                return 1;
+                $returnValue = 1;
             }
         }
+        return $returnValue;
     })
 ;
 

--- a/tests/consoleTest.php
+++ b/tests/consoleTest.php
@@ -11,6 +11,7 @@
 
 use Sismo\Project;
 use Symfony\Component\Console\Tester\ApplicationTester;
+use Sismo\BuildException;
 
 class ConsoleTest extends \PHPUnit_Framework_TestCase
 {
@@ -63,6 +64,18 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(0, $tester->run(array('command' => 'build')));
         $this->assertEquals('Building Project "Twig" (into "eb0a19")'.PHP_EOL.PHP_EOL.'Building Project "Silex" (into "eb0a19")', trim($tester->getDisplay()));
+    }
+
+    public function testBuildForProjectsWithBuildExceptions()
+    {
+        $project1 = $this->getMock('Sismo\Project', null, array('Twig'));
+        $project2 = $this->getMock('Sismo\Project', null, array('Silex'));
+
+        $this->app['sismo']->expects($this->once())->method('getProjects')->will($this->returnValue(array($project1, $project2)));
+        $this->app['sismo']->expects($this->exactly(2))->method('build')->will($this->throwException(new BuildException()));
+
+        $tester = new ApplicationTester($this->console);
+        $this->assertEquals(1, $tester->run(array('command' => 'build')));
     }
 
     public function testVerboseBuildForProject()


### PR DESCRIPTION
From the console, if a single project throws a build exception, the build process is cancelled for all projects.  This means that a mistyped URL in one project can prevent the build of all other projects.  This pull request handles the build exception more gracefully, and adds a test to ensure that builds producing exceptions do not entirely stop the process.  
