### PR TITLE
Move build token into app configuration

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -43,6 +43,7 @@ $app['db.path']     = $app->share(function ($app) {
 
     return $app['data.path'].'/sismo.db';
 });
+$app['build.token'] = getenv('SISMO_BUILD_TOKEN');
 $app['twig.cache.path'] = $app->share(function ($app) { return $app['data.path'].'/cache'; });
 $app['git.path']        = getenv('SISMO_GIT_PATH') ?: 'git';
 $app['git.cmds']        = array();

--- a/src/controllers.php
+++ b/src/controllers.php
@@ -60,7 +60,7 @@ $app->post('/{slug}/build/{token}', function($slug, $token) use ($app) {
     // Boot sismo
     $app['sismo'];
 
-    if (!$server_token = getenv('SISMO_BUILD_TOKEN')) {
+    if (!$server_token = $app['build.token']) {
         throw new NotFoundHttpException('Not found.');
     }
     if ($token != $server_token) {

--- a/tests/controllersTest.php
+++ b/tests/controllersTest.php
@@ -140,9 +140,9 @@ class ControllersTest extends WebTestCase
 
     public function testBuildPage()
     {
-        $orig_token = getenv('SISMO_BUILD_TOKEN');
         $token = md5(mt_rand());
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', $token));
+        $this->app['build.token'] = $token;
+
 
         $project = new Project('Twig');
 
@@ -164,46 +164,37 @@ class ControllersTest extends WebTestCase
 
         $this->assertEquals('Triggered build for project "twig".', $crawler->filter('p')->text());
 
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', $orig_token));
     }
 
     public function testBuildPageTokenNotSet()
     {
-        $orig_token = getenv('SISMO_BUILD_TOKEN');
-        putenv('SISMO_BUILD_TOKEN');
+        $this->app['build.token'] = NULL;
 
         $client = $this->createClient();
         $crawler = $client->request('POST', '/twig/build/foo');
 
         $this->assertEquals('Not found.', $crawler->filter('p')->text());
-
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', $orig_token));
     }
 
     public function testBuildPageInvalidToken()
     {
-        $orig_token = getenv('SISMO_BUILD_TOKEN');
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', md5(mt_rand())));
+        $this->app['build.token'] = md5(mt_rand());
 
         $client = $this->createClient();
         $crawler = $client->request('POST', '/twig/build/foo');
 
         $this->assertEquals('An error occurred', $crawler->filter('p')->text());
-
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', $orig_token));
     }
 
     public function testBuildPageNonExistentProject()
     {
-        $orig_token = getenv('SISMO_BUILD_TOKEN');
         $token = md5(mt_rand());
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', $token));
+        $this->app['build.token'] = $token;
 
         $client = $this->createClient();
         $crawler = $client->request('POST', sprintf('/foobar/build/%s', urlencode($token)));
 
         $this->assertEquals('Project "foobar" not found.', $crawler->filter('p')->text());
 
-        putenv(sprintf('SISMO_BUILD_TOKEN=%s', $orig_token));
     }
 }


### PR DESCRIPTION
Currently, controllers.php uses getenv() directly to get the build token.  This makes it hard to override, and awkward to test.  Why not put specify the token in app.php?  This pull request continues to use getenv(), but moves the definition to app.php.  
