### PR TITLE
Bitbucket url doesn't use 'changeset' anymore

### DIFF
--- a/src/Sismo/BitbucketProject.php
+++ b/src/Sismo/BitbucketProject.php
@@ -30,7 +30,7 @@ class BitbucketProject extends Project
             foreach (explode("\n", $process->getOutput()) as $line) {
                 $parts = explode("\t", $line);
                 if ('origin' == $parts[0] && preg_match('#(?:\:|/|@)bitbucket.org(?:\:|/)(.*?)/(.*?)\.git#', $parts[1], $matches)) {
-                    $this->setUrlPattern(sprintf('https://bitbucket.org/%s/%s/changeset/%%commit%%', $matches[1], $matches[2]));
+                    $this->setUrlPattern(sprintf('https://bitbucket.org/%s/%s/commits/%%commit%%', $matches[1], $matches[2]));
 
                     break;
                 }
@@ -38,7 +38,7 @@ class BitbucketProject extends Project
         } elseif (preg_match('#^[a-z0-9_.-]+/[a-z0-9_.-]+$#i', $this->getRepository())) {
             $repo = preg_split('/\//', $this->getRepository());
 
-            $this->setUrlPattern(sprintf('https://bitbucket.org/%s/changeset/%%commit%%', $this->getRepository()));
+            $this->setUrlPattern(sprintf('https://bitbucket.org/%s/commits/%%commit%%', $this->getRepository()));
             $this->setBitBucketRepository( sprintf('git@bitbucket.org:/%s.git', $this->getRepository()) );
         } else {
             throw new \InvalidArgumentException(sprintf('URL "%s" does not look like a BitBucket repository.', $this->getRepository()));

--- a/tests/Sismo/Tests/BitbucketProjectTest.php
+++ b/tests/Sismo/Tests/BitbucketProjectTest.php
@@ -12,6 +12,8 @@
 namespace Sismo\Tests;
 
 use Sismo\BitbucketProject;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 class BitbucketProjectTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,12 +31,12 @@ class BitbucketProjectTest extends \PHPUnit_Framework_TestCase
     public function getRepositoryProvider()
     {
         return array(
-            array('acme/Demo', 'master', 'git@bitbucket.org:/acme/Demo.git', 'https://bitbucket.org/acme/Demo/changeset/%commit%'),
-            array('acme/Demo@develop', 'develop', 'git@bitbucket.org:/acme/Demo.git', 'https://bitbucket.org/acme/Demo/changeset/%commit%'),
-            array('acme/no.no1', 'master', 'git@bitbucket.org:/acme/no.no1.git', 'https://bitbucket.org/acme/no.no1/changeset/%commit%'),
-            array('no.no/acme', 'master', 'git@bitbucket.org:/no.no/acme.git', 'https://bitbucket.org/no.no/acme/changeset/%commit%'),
-            array('acme/no_no1', 'master', 'git@bitbucket.org:/acme/no_no1.git', 'https://bitbucket.org/acme/no_no1/changeset/%commit%'),
-            array('acme/no-no1', 'master', 'git@bitbucket.org:/acme/no-no1.git', 'https://bitbucket.org/acme/no-no1/changeset/%commit%'),
+            array('acme/Demo', 'master', 'git@bitbucket.org:/acme/Demo.git', 'https://bitbucket.org/acme/Demo/commits/%commit%'),
+            array('acme/Demo@develop', 'develop', 'git@bitbucket.org:/acme/Demo.git', 'https://bitbucket.org/acme/Demo/commits/%commit%'),
+            array('acme/no.no1', 'master', 'git@bitbucket.org:/acme/no.no1.git', 'https://bitbucket.org/acme/no.no1/commits/%commit%'),
+            array('no.no/acme', 'master', 'git@bitbucket.org:/no.no/acme.git', 'https://bitbucket.org/no.no/acme/commits/%commit%'),
+            array('acme/no_no1', 'master', 'git@bitbucket.org:/acme/no_no1.git', 'https://bitbucket.org/acme/no_no1/commits/%commit%'),
+            array('acme/no-no1', 'master', 'git@bitbucket.org:/acme/no-no1.git', 'https://bitbucket.org/acme/no-no1/commits/%commit%'),
         );
     }
 
@@ -44,5 +46,34 @@ class BitbucketProjectTest extends \PHPUnit_Framework_TestCase
     public function testSetRepositoryThrowsAnExceptionIfRepositoryIsNotAGithubOne()
     {
         $project = new BitbucketProject('Twig', 'fabpot/Twig/foobar');
+    }
+
+    public function localRepositoryProvider()
+    {
+        return array(
+            array('https://bitbucket.org/atlassian/stash-example-plugin.git'),
+            array('git@bitbucket.org:atlassian/stash-example-plugin.git'),
+        );
+    }
+
+    /**
+     * @dataProvider localRepositoryProvider
+     */
+    public function testSetRepositoryLocal($url)
+    {
+        $fs = new Filesystem();
+        $repository = sys_get_temp_dir().'/sismo/atlassian/stash-example-plugin';
+        $fs->remove($repository);
+        $fs->mkdir($repository);
+
+        $process = new Process('git init && git remote add origin '.$url, $repository);
+        $process->run();
+
+        $project = new BitbucketProject('Stash', $repository);
+        $this->assertEquals('master', $project->getBranch());
+        $this->assertEquals($repository, $project->getRepository());
+        $this->assertEquals('https://bitbucket.org/atlassian/stash-example-plugin/commits/%commit%', $project->getUrlPattern());
+
+        $fs->remove($repository);
     }
 }


### PR DESCRIPTION
For example: http://hurl.eu/hurls/825b0e84117a66bb48d8f94145f9e39c0d9220e3/199872dd8b10a777484ae371cc338b044b0b309f

-> `HTTP/1.1 301 MOVED PERMANENTLY`
