### PR TITLE
Add missing RuntimeException class

### DIFF
--- a/compile
+++ b/compile
@@ -93,6 +93,7 @@ $classes = array (
     'Symfony\Component\HttpKernel\Exception\FlattenException',
     'Symfony\Component\HttpKernel\HttpKernel',
     'Symfony\Component\HttpKernel\KernelEvents',
+    'Symfony\Component\Process\Exception\RuntimeException',
     'Symfony\Component\Process\ProcessBuilder',
     'Symfony\Component\Process\Process',
     'Symfony\Component\Routing\Exception\InvalidParameterException',


### PR DESCRIPTION
Got the following fatal error while running Sismo on a (restricted) web server:

```
Fatal error: Class 'Symfony\Component\Process\Exception\RuntimeException' not found in /home/willdurand/ci/sismo.php on line 167
```
