### PR TITLE
Allow project to commit the commands it will use

### DIFF
--- a/src/Sismo/Builder.php
+++ b/src/Sismo/Builder.php
@@ -54,6 +54,7 @@ class Builder
     {
         if (file_exists($this->buildDir.'/sismo.yml')) {
             echo 'Using sismo.yml';
+
             return $this->buildFromYaml();
         }
 
@@ -193,6 +194,5 @@ class Builder
 
         return $globalProcess;
     }
-
 }
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
This commit allows the tests to be committed rather than generated each time.
This is useful to me to define inside the project how the test environment works, mainly for composer and codeception
