### PR TITLE
PdoStorage missing in compiled sismo.php

### DIFF
--- a/compile
+++ b/compile
@@ -145,6 +145,7 @@ $classes = array (
     'Sismo\SSHProject',
     'Sismo\Sismo',
     'Sismo\Storage\Storage',
+    'Sismo\Storage\PdoStorage',
     'SensioLabs\AnsiConverter\AnsiToHtmlConverter',
     'SensioLabs\AnsiConverter\Theme\Theme',
 );


### PR DESCRIPTION
While switching from sqlite to mysql due to a database locking issue i noticed, that the provided Sismo/Storage/PdoStorage class was not included in sismo.php

This pull request adds the class to the compilation process.