### PR TITLE
Fixed typo

### DIFF
--- a/compile
+++ b/compile
@@ -5,7 +5,7 @@ if (function_exists('twig_template_get_attributes')) {
     die("You must disable the C Twig extension before compiling Sismo.\n");
 }
 
-// Compiles Simo into one big PHP file (images and CSS served by Silex directly)
+// Compiles Sismo into one big PHP file (images and CSS served by Silex directly)
 // Can be used on the web and the CLI
 
 use Symfony\Component\ClassLoader\ClassCollectionLoader;


### PR DESCRIPTION
There is a typo: Simo -> Sismo