### PR TITLE
commits with status "building" should be on top

### DIFF
--- a/src/Sismo/Storage/PdoStorage.php
+++ b/src/Sismo/Storage/PdoStorage.php
@@ -174,7 +174,7 @@ class PdoStorage implements StorageInterface
         }
 
         // related commits
-        $stmt = $this->db->prepare('SELECT sha, author, date, build_date, message, status, output FROM `commit` WHERE slug = :slug ORDER BY build_date DESC LIMIT 100');
+        $stmt = $this->db->prepare('SELECT sha, author, date, build_date, message, status, output FROM `commit` WHERE slug = :slug ORDER BY `status` = "building" DESC, build_date DESC LIMIT 100');
         $stmt->bindValue(':slug', $project->getSlug(), \PDO::PARAM_STR);
 
         if (false === $stmt->execute()) {

--- a/src/Sismo/Storage/Storage.php
+++ b/src/Sismo/Storage/Storage.php
@@ -86,7 +86,7 @@ class Storage implements StorageInterface
         }
 
         // related commits
-        $stmt = $this->db->prepare('SELECT sha, author, date, build_date, message, status, output FROM `commit` WHERE slug = :slug ORDER BY build_date DESC LIMIT 100');
+        $stmt = $this->db->prepare('SELECT sha, author, date, build_date, message, status, output FROM `commit` WHERE slug = :slug ORDER BY `status` = "building" DESC, build_date DESC LIMIT 100');
         $stmt->bindValue(':slug', $project->getSlug(), SQLITE3_TEXT);
 
         if (false === $results = $stmt->execute()) {


### PR DESCRIPTION
At the moment the current building commit is on bottom of the list (in web interface).
Also the CCActivity is always "Sleeping" because it uses the first commit (https://github.com/FriendsOfPHP/Sismo/blob/master/src/Sismo/Project.php#L221).

Both issues are fixed by this PR.